### PR TITLE
STYLE: fix #40 info group name corrected

### DIFF
--- a/cogs/maincog.py
+++ b/cogs/maincog.py
@@ -17,7 +17,7 @@ class Main(commands.Cog):
         self.bot = bot
 
     info_group = app_commands.Group(
-        name="info", description="Gives information about server, member or channel."
+        name="info", description="Gives information about server and member."
     )
 
     async def cog_load(self):


### PR DESCRIPTION
`info_group` name has been changed from `log` to `info`. 
Changed the `info_group` description to match commands. 