### PR TITLE
FIX: index out of range in /info member #65

### DIFF
--- a/cogs/maincog.py
+++ b/cogs/maincog.py
@@ -102,10 +102,10 @@ class Main(commands.Cog):
 
     def __count_top_three_roles(self, member: discord.Member) -> str:
         roles = ""
+        rolelen = len(member.roles)
 
-        roles += f"<@&{member.roles[-1].id}>, "
-        roles += f"<@&{member.roles[-2].id}>, "
-        roles += f"<@&{member.roles[-3].id}>."
+        for i in range(1, rolelen, 1):
+            roles += f"<@&{member.roles[-i].id}>"
 
         return roles
 


### PR DESCRIPTION
# Changes

- adjusted __count_top_three_roles to check total length of member.roles
- created for loop to cycle through roles with a range start from 1 and ending at the length
- issue #65 