### PR TITLE
RELEASE: v1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,164 @@ response*
 .idea 
 flask
 activate.sh
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/cogs/emp.py
+++ b/cogs/emp.py
@@ -24,7 +24,7 @@ from discord import app_commands
 from github import Github
 
 
-class BotCog(
+class Emp(
     commands.GroupCog,
     group_name="emperor",
     description="All commands relate to emperor, and developers working on emperor",
@@ -180,4 +180,4 @@ async def setup(bot):
     for guild in bot.config.GUILD_ID:
         guild_objects.append(discord.Object(id=guild))
 
-    await bot.add_cog(BotCog(bot), guilds=guild_objects)
+    await bot.add_cog(Emp(bot), guilds=guild_objects)

--- a/res/json/extras.json
+++ b/res/json/extras.json
@@ -1,0 +1,15 @@
+{
+    "disabled_commands": [
+        "gpt_prompt"
+    ],
+    "command_signatures": [
+        "reddit_search",
+        "ddg_search",
+        "ddg_lucky",
+        "gpt_prompt",
+        "info_server",
+        "info_member",
+        "tutorials_git",
+        "uptime"
+    ]
+}

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ import os
 from getpass import getpass
 from src.ServerUtils import Utils
 
-EMPEROR_VERSION = "v0.1.5"
+EMPEROR_VERSION = "v1.0.0"
 
 
 def check_input(var_input: str) -> str:
@@ -157,7 +157,7 @@ if check_input(create_ENV_file) == "yes":
 # -------------------------------------------------
 # Do not change anything here
 BOT_ENV_VERSION='{EMPEROR_VERSION}'
-COGS = ["bot", "event",  "maincog", "admin", "mod", "api", "help"]
+COGS = ["emp", "event",  "core", "dev", "mod", "api", "help"]
 COLOUR = "4915330"	
 # -------------------------------------------------
 #
@@ -173,7 +173,7 @@ LOG_CHANNEL_IDS='{{{write_to_file_dict(log_channel_ids)}}}'
 STAFF_IDS='{{{write_to_file_dict(staff_ids)}}}'
 """
     # Creates the .env file with the contents parsed above
-    Utils.writeToFile(filename="", content=content_env, mode="w", extension=".env")
+    Utils.write_to_file(filename="", content=content_env, mode="w", extension=".env")
 
 # Creates a logs folder, where Lj stores all the logs
 print("Creating logs folder for Lj....")

--- a/src/Lj.py
+++ b/src/Lj.py
@@ -59,7 +59,7 @@ class Lj:
         # Simple try and except where it saves to file
         try:
             # save to file
-            Utils.writeToFile(
+            Utils.write_to_file(
                 self.log_file, clean_info_format, extension=".log", directory="logs/"
             )
             return True
@@ -95,7 +95,7 @@ class Lj:
         # Simple try and except where it saves to file
         try:
             # save to file
-            Utils.writeToFile(
+            Utils.write_to_file(
                 self.log_file, clean_warn_format, extension=".log", directory="logs/"
             )
             return True
@@ -137,7 +137,7 @@ class Lj:
         # Simple try and except where it saves to file
         try:
             # save to file
-            Utils.writeToFile(
+            Utils.write_to_file(
                 self.log_file, clean_error_format, extension=".log", directory="logs/"
             )
             return True

--- a/src/ServerUtils.py
+++ b/src/ServerUtils.py
@@ -30,12 +30,9 @@ class Utils:
     """
 
     @staticmethod
-    def writeToFile(
+    def write_to_file(
         filename, content, mode="a", extension=".txt", directory=""
     ) -> None:
-        # Writes the data into a text file
-        # NOTE: when giving the filename, do not use .txt since the function already does that for you.
-
         """Writes the data to a given file name.
         Only needs filename and content to work.
         Optinal args provided, see Docs.
@@ -57,7 +54,36 @@ class Utils:
             f"{directory}{filename}{extension}", mode, encoding="utf-8"
         ) as file:  # NOTE: reference ".txt".
             file.write(content + "\n")
-            file.close()
+        file.close()
+
+
+    @staticmethod
+    def write_to_json(
+        filename: str,
+        content: dict,
+        mode: str = "a",
+        directory=""
+    ) -> None:
+        """
+        Writes to a json file.
+        Only needs filename and content to work
+
+        Args:
+            filename (str): name of the json file to be written to
+            content (dict): data to be wirtten
+            mode (str, optional): modes for writing. Defaults to "a", appending.
+            directory (str, optional): where to save the file. Defaults to "", current directory.
+        """
+        
+        with open(
+            f"{directory}{filename}.json",
+            mode,
+            encoding="utf-8"
+        ) as json_file:
+            json.dump(content, json_file, indent=4)
+        
+        json_file.close()
+
 
     @staticmethod
     def read_from_json(path_to_file: str) -> dict:
@@ -88,7 +114,7 @@ class Utils:
         |   __|_____ ___ ___ ___ ___ ___
         |   __|     | . | -_|  _| . |  _|
         |_____|_|_|_|  _|___|_| |___|_|
-             v0.1.5 |_| GPL-3.0-only 
+             v1.0.0 |_| GPL-3.0-only 
 
         © 2022-2023 School of Computing Dev Team
 

--- a/src/errors/checks.py
+++ b/src/errors/checks.py
@@ -18,25 +18,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import discord
 
-from discord.ext import commands
-from dotenv import load_dotenv
-from src.ServerUtils import Utils
-from src.config import Settings
-from src.Emperor import Emperor
-
-load_dotenv()
-
-config = Settings()
-
-Utils.print_branding()  # Prints Emperor Logo Branding
-
-# Sending the intents
-intents = discord.Intents.default()
-intents.message_content = True
-intents.members = True
-intents.presences = True
-intents.reactions = True
-
-Emperor = Emperor(intents, config)
-
-Emperor.run(config.TOKEN)
+class DisabledCommand(discord.app_commands.CheckFailure):
+    """
+    
+    Raised when a command is disabled by staff and is being executed
+    
+    """
+    pass


### PR DESCRIPTION
## Changes

### Added

- Command toggling v0.1.0
     - By default, all commands should be enabled.
     - Currently, only `API` and `core` commands support toggling.
     - Commands now have an extra key called `command_signature`. Used to block commands from being executed.
     - Only staff members can run the commands below. 
          - `enable`: Enables a command, allows it to run when called. (One at a time)
          - `disable`: Prevents the command from being executed, as it has been disabled by staff team. (Also, one at a time)
- `write_to_json()` writes python dictionary to file.
- `src/errors/check.py`: All custom check errors are listed in the file, currently only `DisabledCommand`.


### Changed

- Moved `sync` command from `main.py` to `dev` (`admin`) cog.
- Renamed `maincog` to `core`.
- Renamed `admin` to `dev`.
- Renamed `bot` file and `botCog` class to `emp`/`Emp` for consistency.
- Renamed `writeToFile()` in ServerUtils to `write_to_file`
- Changed check condition on `dev` to allow staff members (with staff role) to run the commands.

### Fixed

- When an error occurs, in `reload`, `load` and `unload`. The message was not deleted after 2 seconds as intended to, now it does.
- Disabled `chatgpt_prompt` command for the time being. (reason listed in #87)
