### PR TITLE
BUG FIX: Help command fixed

### DIFF
--- a/cogs/api.py
+++ b/cogs/api.py
@@ -29,7 +29,7 @@ from typing import List, Tuple
 from src.errors.checks import DisabledCommand
 
 
-class API(commands.Cog):
+class API(commands.Cog, description="Commands that relate to APIs"):
     """
      API Cog
 

--- a/cogs/core.py
+++ b/cogs/core.py
@@ -26,7 +26,7 @@ from discord import app_commands
 from src.errors.checks import DisabledCommand
 from src.ServerUtils import Utils
 
-class Core(commands.Cog):
+class Core(commands.Cog, description="Bunch of commands"):
     """
     Main Cog
 

--- a/cogs/dev.py
+++ b/cogs/dev.py
@@ -23,7 +23,7 @@ import typing
 from discord.ext import commands
 
 
-class Dev(commands.Cog):
+class Dev(commands.Cog, description="Developer commands"):
     """
     Admin cog
 
@@ -66,7 +66,7 @@ class Dev(commands.Cog):
         await message.delete()
         await ctx.message.delete()
 
-    @commands.command(name="reload")
+    @commands.command(name="reload", description="unloads and loads the cog")
     async def reload(self, ctx: commands.Context, cog: str) -> None:
         """
         Allows the changes to be run without having the restart the discord bot
@@ -89,7 +89,7 @@ class Dev(commands.Cog):
             message = await ctx.send(exc)
             await self.__delete_messages_after(message, ctx)
 
-    @commands.command(name="load")
+    @commands.command(name="load", description="Loads the cog, so commands inside can be used")
     async def load(self, ctx: commands.Context, cog: str) -> None:
         """
         Loads a specifc cog
@@ -109,7 +109,7 @@ class Dev(commands.Cog):
             message = await ctx.send(exc)
             await self.__delete_messages_after(message, ctx)
 
-    @commands.command(name="unload")
+    @commands.command(name="unload", description="Unloads the cog, prevents commands form being executed/known.")
     async def unload(self, ctx: commands.Context, cog: str) -> None:
         """
         Unloads a specifc cog

--- a/cogs/emp.py
+++ b/cogs/emp.py
@@ -25,8 +25,8 @@ from github import Github
 
 
 class Emp(
-    commands.GroupCog,
-    group_name="emperor",
+    commands.Cog,
+    name="Emperor",
     description="All commands relate to emperor, and developers working on emperor",
 ):
     """
@@ -34,6 +34,9 @@ class Emp(
     All commands relate to the emperor, and developers working
     on the emperor.
     """
+    
+    emperor_group = app_commands.Group(name="emperor",
+                                   description="All commands relate to emperor, and developers working on emperor")
 
     def __init__(self, bot):
         self.bot = bot
@@ -51,8 +54,8 @@ class Emp(
         )
         await interaction.response.send_message(f"<@{interaction.user.id}>, {error}")
 
-    @app_commands.command(name="contribute", description="Contribute to Emperor")
-    async def hello(self, interaction: discord.Interaction) -> None:
+    @emperor_group.command(name="contribute", description="Contribute to Emperor")
+    async def contribute(self, interaction: discord.Interaction) -> None:
         """
         Instructions on how to contribute to Emperor
 
@@ -101,7 +104,7 @@ Remember: **Do not be scared to contribute, no one will make a fool of you, we w
     # pylint: disable=too-many-arguments
     # Anything related to Github goes here!
     # PyGithub Wrapper -> Github REST API
-    @app_commands.command(
+    @emperor_group.command(
         name="issue", description="Creates an Issue on Emperor's Repo."
     )
     async def create_issue(

--- a/cogs/emp.py
+++ b/cogs/emp.py
@@ -34,7 +34,7 @@ class Emp(
     All commands relate to the emperor, and developers working
     on the emperor.
     """
-    
+
     emperor_group = app_commands.Group(name="emperor",
                                    description="All commands relate to emperor, and developers working on emperor")
 

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -42,7 +42,7 @@ class MyHelpCommand(commands.HelpCommand):
         description = f"""{self.context.bot.description}
         Using `{self.context.clean_prefix}help` shows this embed again.
         NOTE: Slash Commnads will not work with `{self.context.clean_prefix}help [command]`."""
-        
+
         for cog, command in mapping.items():
             cog_name = getattr(cog, "qualified_name", "No Category")
 

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -21,15 +21,12 @@ import discord
 
 from discord.ext import commands
 from discord import app_commands
-from discord.ext.commands import Cog
 from typing import Mapping, Optional, List
-
-from discord.ext.commands.cog import Cog
 
 class MyHelpCommand(commands.HelpCommand):
 
 
-    async def send_bot_help(self, mapping: Mapping[Optional[Cog], List[commands.Command]]):
+    async def send_bot_help(self, mapping: Mapping[Optional[commands.Cog], List[commands.Command]]):
         """
         Sends an embed with all the commands for the server
         
@@ -46,9 +43,9 @@ class MyHelpCommand(commands.HelpCommand):
         Using `{self.context.clean_prefix}help` shows this embed again.
         NOTE: Slash Commnads will not work with `{self.context.clean_prefix}help [command]`."""
         
-        for cog, command in mapping.items():            
+        for cog, command in mapping.items():
             cog_name = getattr(cog, "qualified_name", "No Category")
-                        
+
             if cog_name in ["Dev", "Event", "Help", "No Category"]:
                 continue
             
@@ -58,11 +55,11 @@ class MyHelpCommand(commands.HelpCommand):
             
             app_commands_union = cog.get_app_commands() if not (cog is None) else []
             num = 0
-            for i in range(len(app_commands_union)):
-                if isinstance(app_commands_union[i], app_commands.Command):
+            for app_command in app_commands_union:
+                if isinstance(app_command, app_commands.Command):
                     num += 1
-                if isinstance(app_commands_union[i], app_commands.Group):
-                    num += len(app_commands_union[i].commands)
+                if isinstance(app_command, app_commands.Group):
+                    num += len(app_command.commands)
             
             embed.add_field(name=f'{cog_name} ({len(commands_list) + num})',
                                 value=cog.description if not (cog is None) else "Nothing here",
@@ -87,7 +84,7 @@ class MyHelpCommand(commands.HelpCommand):
         channel = self.get_destination()
         await channel.send(embed=embed)
         
-    async def send_cog_help(self, cog: Cog) -> None:
+    async def send_cog_help(self, cog: commands.Cog) -> None:
         """Gathers information about the cog and sends an embed with the information.
 
         Args:

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -24,6 +24,8 @@ from discord import app_commands
 from discord.ext.commands import Cog
 from typing import Mapping, Optional, List
 
+from discord.ext.commands.cog import Cog
+
 class MyHelpCommand(commands.HelpCommand):
 
 
@@ -38,51 +40,81 @@ class MyHelpCommand(commands.HelpCommand):
             discord.Embed - contains all commands formated correctly
         
         """
-        embed = discord.Embed(title="Bot help")
-        # `mapping` is a dict of the bot's cogs, which map to their commands
-        # print(mapping)
+        embed = discord.Embed(title="Emperor Help", color=self.context.bot.config.COLOUR)
 
-        # NOTE: app_commands do not have a normal cooldown
-        # attribute, converting all the app_commands
-        # into hybrid commands would give them cooldown attribute
-
-        description = f"{self.context.bot.description}\nUse `e!help` to see this embed again!\nAny `\` commands are slash commands, while `e!` are normal commands."
-        for commands in mapping.items():
-            for item in commands:
-                # list object is normal text commands
-                if item.__class__ == list:
-                    for i in item:
-                        if i.__class__ is discord.app_commands.Group:
-                            continue
-                        if i.cog_name in [None, "Admin"]:
-                            continue
-
-                        description += f"\n• **e!{i.qualified_name}**: {i.description}"
-
-                # Any Cog object contains app_commands which
-                # is slash commands
-                elif item.__class__.__base__ == Cog:
-                    # Removing Admin and Event Cogs
-                    # Contain special commands that cannot be
-                    # used by normal users
-                    if item.__cog_name__ in ["Admin", "Event"]:
-                        continue
-
-                    description += f"\n\n**__{item.__cog_name__}__**\n"
-
-                    for command in item.walk_app_commands():
-                        if command.__class__ is discord.app_commands.Group:
-                            continue
-
-                        description += f"\n• **/{command.qualified_name}**: {command.description}"
-
+        description = f"""{self.context.bot.description}
+        Using `{self.context.clean_prefix}help` shows this embed again.
+        NOTE: Slash Commnads will not work with `{self.context.clean_prefix}help [command]`."""
+        
+        for cog, command in mapping.items():            
+            cog_name = getattr(cog, "qualified_name", "No Category")
+                        
+            if cog_name in ["Dev", "Event", "Help", "No Category"]:
+                continue
+            
+            # Figure out how many commands are
+            # inside the cog
+            commands_list = cog.get_commands() if not (cog is None) else command
+            
+            app_commands_union = cog.get_app_commands() if not (cog is None) else []
+            num = 0
+            for i in range(len(app_commands_union)):
+                if isinstance(app_commands_union[i], app_commands.Command):
+                    num += 1
+                if isinstance(app_commands_union[i], app_commands.Group):
+                    num += len(app_commands_union[i].commands)
+            
+            embed.add_field(name=f'{cog_name} ({len(commands_list) + num})',
+                                value=cog.description if not (cog is None) else "Nothing here",
+                                inline=False)
+                
         embed.description = description
-
+        embed.set_author(name=self.context.bot.user.display_name, icon_url=self.context.bot.user.display_avatar)
+        embed.set_footer(text=f'run by {self.context.author.display_name} | ID: {self.context.author.id}',
+                         icon_url=self.context.author.display_avatar)
+        
         channel = self.get_destination()
         await channel.send(embed=embed)
 
+    async def send_command_help(self, command):
+        embed = discord.Embed(title=self.get_command_signature(command),
+                              color=self.context.bot.config.COLOUR)
+        embed.add_field(name="Help", value=command.help)
+        alias = command.aliases
+        if alias:
+            embed.add_field(name="Aliases", value=", ".join(alias), inline=False)
 
-class Help(commands.Cog):
+        channel = self.get_destination()
+        await channel.send(embed=embed)
+        
+    async def send_cog_help(self, cog: Cog) -> None:
+        """Gathers information about the cog and sends an embed with the information.
+
+        Args:
+            cog (Cog): The cog the information is about.
+        """
+        channel = self.get_destination()
+        
+        embed = discord.Embed(title=f'{cog.qualified_name}', color=self.context.bot.config.COLOUR)
+        
+        # embed.add_field(name="Commands", value="Commands that can be run through the prefix", inline=False)
+        for command in cog.walk_commands():
+            embed.add_field(name=command.name, value=command.description, inline=True)
+        
+        # embed.add_field(name="Slash Commands", value="Commands that are built into the client by the bot", inline=False)
+        for command in cog.walk_app_commands():
+            if isinstance(command, app_commands.Group):
+                continue
+            embed.add_field(name=f'{command.qualified_name}', value=command.description, inline=True)
+        
+        embed.description = cog.description
+        embed.set_author(name=self.context.bot.user.display_name, icon_url=self.context.bot.user.display_avatar)
+        embed.set_footer(text=f'run by {self.context.author.display_name} | ID: {self.context.author.id}',
+                         icon_url=self.context.author.display_avatar)
+        
+        await channel.send(embed=embed)
+
+class Help(commands.Cog, description="Shows this message."):
     """
     Help command that showcases all the possible commands for the bot
     """

--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -28,7 +28,7 @@ from discord import app_commands
 from src.ServerUtils import Utils
 
 
-class Mod(commands.Cog):
+class Mod(commands.Cog, description="Moderation commands"):
     """
     Moderation cog
 

--- a/setup.py
+++ b/setup.py
@@ -157,10 +157,10 @@ if check_input(create_ENV_file) == "yes":
 # -------------------------------------------------
 # Do not change anything here
 BOT_ENV_VERSION='{EMPEROR_VERSION}'
-COGS = ["emp", "event",  "core", "dev", "mod", "api", "help"]
+COGS = COGS = ["api", "core", "emp", "mod", "event", "dev", "help"]
 COLOUR = "4915330"	
 # -------------------------------------------------
-#
+
 # Ensure that all fields are given correct values.
 # Also, the bot should have access to the guild and log channel
 # otherwise an error will occur

--- a/src/Emperor.py
+++ b/src/Emperor.py
@@ -39,7 +39,7 @@ class Emperor(commands.Bot):
         self.lj = Lj()
 
         super().__init__(
-            description="Discord made by School of Computing Dev team.",
+            description="Emperor bot made by School of Computing Dev team.",
             command_prefix=commands.when_mentioned_or(self.config.BOT_PREFIX),
             intents=p_intents,
         )


### PR DESCRIPTION
## Changelog

### Added
- Description for all cogs

### Changed
- Prefix is now dynamic inside embeds instead of preset.
- `emp` cog derives from `commands.Cog` instead of `commands.GroupCog`
- All help embeds have the correct colour assigned
- Dev commands have been removed from the top level help embed. You can still do `<prefix>help Dev`.


Fixes #92, #93, #94, #95 and #96.