### PR TITLE
BUG FIX : Core commands fixes

### DIFF
--- a/cogs/core.py
+++ b/cogs/core.py
@@ -340,9 +340,18 @@ List of Youtube tutorials:
 
 """,
             "thumbnail": {"url": "attachment://gitLogo.png"},
-            "footer": {"text": "Emperor"},
+            "author": {
+                "name": "Emperor",
+                "icon_url": self.bot.user.display_avatar.url
+            },
+            "footer": {
+                "text": f"run by {interaction.user.display_name} ID: {interaction.user.id} | Emperor", 
+                "icon_url": interaction.user.display_avatar.url
+            },
             "title": "Git",
+            "color": self.bot.config.COLOUR
         }
+        
 
         await interaction.response.send_message(
             embed=discord.Embed.from_dict(git_embed), file=icon_file

--- a/cogs/core.py
+++ b/cogs/core.py
@@ -371,7 +371,7 @@ List of Youtube tutorials:
         """
 
         await ctx.send(
-            f"The bot has been online for: <t:{int(dt.timestamp(self.bot.uptime))}:R>"
+            f"The bot came online <t:{int(dt.timestamp(self.bot.uptime))}:R>."
         )
 
 

--- a/cogs/core.py
+++ b/cogs/core.py
@@ -135,13 +135,10 @@ class Core(commands.Cog, description="Bunch of commands"):
         return num
 
     def __count_top_three_roles(self, member: discord.Member) -> str:
-        roles = ""
-        rolelen = len(member.roles)
 
-        for i in range(1, rolelen, 1):
-            roles += f"<@&{member.roles[-i].id}>"
+        roles_list = [f'<@&{role.id}>' for role in member.roles]
 
-        return roles
+        return ", ".join(roles_list[:-4:-1]) + "."
 
     def __count_emojis(self, guild: discord.Guild) -> str:
         """


### PR DESCRIPTION
## Changelog

### Changed

- `info member` counts the top 3 roles correctly and with a separator (`,`).
- Git embed footer now shows the user who ran the command with their ID.
- Git embed also has its colour assigned based on config value.
- Git embed author has been set to Emperor.
- Uptime grammar fixed (?).

Closes #98, #99, #100 and #101.